### PR TITLE
explicitly add self.list_select_related to select_related

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,2 +1,2 @@
 service_name: travis-pro
-repo_token: xWNB1OQ8bwErhS8UGvNNsYOvbG1k1Fka6
+repo_token: MhF2IBTCYvVINTUcVvhZ3tmSuVqShdqQF

--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,2 +1,2 @@
 service_name: travis-pro
-repo_token: MhF2IBTCYvVINTUcVvhZ3tmSuVqShdqQF
+repo_token: xWNB1OQ8bwErhS8UGvNNsYOvbG1k1Fka6

--- a/related_admin/__init__.py
+++ b/related_admin/__init__.py
@@ -57,6 +57,11 @@ class RelatedFieldAdmin(with_metaclass(RelatedFieldAdminMetaclass, admin.ModelAd
         # include all related fields in queryset
         select_related = [field.rsplit('__', 1)[0] for field in self.list_display if '__' in field]
 
+        # explicitly add contents of self.list_select_related to select_related
+        if self.list_select_related:
+            for field in self.list_select_related:
+                select_related.append(field)
+
         # Include all foreign key fields in queryset.
         # This is based on ChangeList.get_query_set().
         # We have to duplicate it here because select_related() only works once.

--- a/test_app/main/admin.py
+++ b/test_app/main/admin.py
@@ -14,6 +14,7 @@ class AlbumAdmin(RelatedFieldAdmin):
 class MusicianAdmin(admin.ModelAdmin):
     list_display = ('first_name', 'last_name')
 
+
 class ConcertAdmin(RelatedFieldAdmin):
     list_display = ('name', 'main_performer_link')
     list_select_related = ('main_performer',)

--- a/test_app/main/admin.py
+++ b/test_app/main/admin.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 
 from django.contrib import admin
-from .models import Album, Musician
+from .models import Album, Musician, Concert
 from related_admin import RelatedFieldAdmin
+from django.core.urlresolvers import reverse
+from cgi import escape
 
 
 class AlbumAdmin(RelatedFieldAdmin):
@@ -12,6 +14,16 @@ class AlbumAdmin(RelatedFieldAdmin):
 class MusicianAdmin(admin.ModelAdmin):
     list_display = ('first_name', 'last_name')
 
+class ConcertAdmin(RelatedFieldAdmin):
+    list_display = ('name', 'main_performer_link')
+    list_select_related = ('main_performer',)
+
+    def main_performer_link(self, obj):
+        url = reverse("admin:main_musician_change", args=[obj.main_performer.id])
+        return '<a href="%s">%s</a>' % (url, escape(str(obj)))
+    main_performer_link.allow_tags = True
+    main_performer_link.short_description = "Main performer"
 
 admin.site.register(Album, AlbumAdmin)
 admin.site.register(Musician, MusicianAdmin)
+admin.site.register(Concert, ConcertAdmin)

--- a/test_app/main/fixtures/data.json
+++ b/test_app/main/fixtures/data.json
@@ -46,6 +46,14 @@
     },
     {
         "fields": {
+            "main_performer": 1,
+            "name": "First concert"
+        },
+        "model": "main.concert",
+        "pk": 1
+    },
+    {
+        "fields": {
             "date_joined": "2015-11-12T18:16:03.886-00:00",
             "email": "admin@admin.com",
             "first_name": "",

--- a/test_app/main/migrations/0003_auto_20160612_0933.py
+++ b/test_app/main/migrations/0003_auto_20160612_0933.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('main', '0002_auto_20160110_0045'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Concert',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('name', models.CharField(max_length=100)),
+            ],
+        ),
+        migrations.AlterField(
+            model_name='album',
+            name='artist',
+            field=models.ForeignKey(blank=True, to='main.Musician', null=True),
+        ),
+        migrations.AlterField(
+            model_name='musician',
+            name='last_name',
+            field=models.CharField(max_length=50, null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='concert',
+            name='main_performer',
+            field=models.ForeignKey(to='main.Musician'),
+        ),
+    ]

--- a/test_app/main/models.py
+++ b/test_app/main/models.py
@@ -15,3 +15,8 @@ class Album(models.Model):
     artist = models.ForeignKey(Musician, on_delete=models.CASCADE, null=True, blank=True)
     name = models.CharField(max_length=100)
     release_date = models.DateField()
+
+
+class Concert(models.Model):
+    name = models.CharField(max_length=100)
+    main_performer = models.ForeignKey(Musician, on_delete=models.CASCADE)

--- a/test_app/tests.py
+++ b/test_app/tests.py
@@ -13,3 +13,8 @@ class AdminFilterTests(TestCase):
         self.assertTrue(self.client.login(username='admin', password='admin'))
         response = self.client.get(reverse("admin:main_album_changelist"))
         self.assertEqual(response.status_code, 200)
+
+    def test_admin_views_list_select_related_competition(self):
+        self.assertTrue(self.client.login(username='admin', password='admin'))
+        response = self.client.get(reverse("admin:main_concert_changelist"))
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
Added code to explicitly add contents of self.list_select_related to select_related when creating a queryset. This can be useful when list_display contains a method name a that method uses a foreign key not otherwise listed in list_display.
