### PR TITLE
Automatic detection of boolean fields

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ Just use it instead of model.Admin::
    from related_admin import getter_for_related_field
 
    class FooAdmin(RelatedFieldAdmin):
-       # these fields will work automatically:
+       # these fields will work automatically (and boolean fields will display an icon):
        list_display = ('address__phone','address__country__country_code','address__foo')
 
        # ... but you can also define them manually if you need to override short_description or boolean parameter:

--- a/related_admin/compat.py
+++ b/related_admin/compat.py
@@ -1,0 +1,19 @@
+import django
+from django.contrib.admin.utils import display_for_field as django_display_for_field
+
+
+if django.VERSION >= (1, 9):
+    def get_empty_value_display(model_admin):
+        return model_admin.get_empty_value_display()
+
+    display_for_field = django_display_for_field
+else:
+    def get_empty_value_display(model_admin):
+        from django.contrib.admin.views.main import EMPTY_CHANGELIST_VALUE
+        return EMPTY_CHANGELIST_VALUE
+
+    def display_for_field(value, field, empty_value_display):
+        if value is None:
+            return empty_value_display
+        else:
+            return django_display_for_field(value, field)

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-related-admin',
-    version='0.4.0',
+    version='0.5.0',
     packages=['related_admin'],
     include_package_data=True,
     description="Allow foreign key attributes in list_display with '__'",

--- a/test_app/main/admin.py
+++ b/test_app/main/admin.py
@@ -18,16 +18,16 @@ from .models import Album, Concert, Musician
 class AlbumAdmin(RelatedFieldAdmin):
     list_display = ('name', 'artist', 'artist__first_name', 'artist__last_name', 'artist__full_name', 'artist__active', '__str__')
 
-    artist__active = getter_for_related_field('artist__active', boolean=True)
-
 
 class MusicianAdmin(admin.ModelAdmin):
     list_display = ('first_name', 'last_name')
 
 
 class ConcertAdmin(RelatedFieldAdmin):
-    list_display = ('name', 'main_performer_link')
+    list_display = ('name', 'main_performer_link', 'main_performer__is_on_tour')
     list_select_related = ('main_performer',)
+
+    main_performer__is_on_tour = getter_for_related_field('main_performer__is_on_tour', boolean=True)
 
     def main_performer_link(self, obj):
         url = reverse("admin:main_musician_change", args=[obj.main_performer.id])

--- a/test_app/main/models.py
+++ b/test_app/main/models.py
@@ -14,6 +14,9 @@ class Musician(models.Model):
     def __str__(self):
         return self.full_name()
 
+    def is_on_tour(self):
+        return self.active
+
 
 class Album(models.Model):
     artist = models.ForeignKey(Musician, on_delete=models.CASCADE, null=True, blank=True)

--- a/test_app/settings.py
+++ b/test_app/settings.py
@@ -65,6 +65,9 @@ MIDDLEWARE = (
 
 if django.VERSION < (1, 10):
     MIDDLEWARE_CLASSES = MIDDLEWARE
+else:
+    session_auth_middleware = 'django.contrib.auth.middleware.SessionAuthenticationMiddleware'
+    MIDDLEWARE = tuple(m for m in MIDDLEWARE if m != session_auth_middleware)
 
 
 ROOT_URLCONF = 'test_app.urls'

--- a/test_app/tests.py
+++ b/test_app/tests.py
@@ -23,4 +23,5 @@ class AdminFilterTests(TestCase):
     def test_admin_views_list_select_related_competition(self):
         self.assertTrue(self.client.login(username='admin', password='admin'))
         response = self.client.get(reverse("admin:main_concert_changelist"))
+        self.assertContains(response, '<td class="field-main_performer__is_on_tour">%s</td>' % _boolean_icon(True), html=True)
         self.assertEqual(response.status_code, 200)

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,5 @@ deps =
     flake8-comprehensions
     flake8-import-order
     flake8-tidy-imports
-    flake8-class
     flake8-builtins
     flake8-strict


### PR DESCRIPTION
Adds support for automatically detecting boolean fields, so you can get 
![selection_014](https://cloud.githubusercontent.com/assets/33840/25153179/aa25e778-2459-11e7-9d87-2adcdade6808.png)

Instead of
![selection_015](https://cloud.githubusercontent.com/assets/33840/25153193/b6f17c88-2459-11e7-9511-980b16e129d1.png)

By only listing the field in `list_display` (like vanilla Django)
```python
class AlbumAdmin(RelatedFieldAdmin):
    list_display = ('artist__active',)
```

And without requiring an explicit `boolean=True`:
```python
class AlbumAdmin(RelatedFieldAdmin):
    list_display = ('artist__active',)

    # Not needed
    artist__active = getter_for_related_field('artist__active', boolean=True)
```